### PR TITLE
Workaround micropython #13377 uart-flush-too-slow

### DIFF
--- a/umodbus/serial.py
+++ b/umodbus/serial.py
@@ -9,6 +9,7 @@
 #
 
 # system packages
+import os
 from machine import UART
 from machine import Pin
 import struct
@@ -107,6 +108,12 @@ class CommonRTUFunctions(object):
         super().__init__()
         # UART flush function is introduced in Micropython v1.20.0
         self._has_uart_flush = callable(getattr(UART, "flush", None))
+        sysname, _nodename, release, _version, _machine = os.uname()
+        if sysname == "rp2" and release in ("1.22.0", "1.22.1"):
+            # See: https://github.com/micropython/micropython/issues/13377
+            self._has_uart_flush = False
+            print("https://github.com/micropython/micropython/issues/13377")
+
         self._uart = UART(uart_id,
                           baudrate=baudrate,
                           bits=data_bits,


### PR DESCRIPTION
**Background**

Bug in micropython
> v1.22.1: uart.flush() takes way too long
> https://github.com/micropython/micropython/issues/13377
> Affected versions: rp2, v1.22.0 and v1.22.1

**This PR is a workaround for above bug**

In the affected versions, `uart.flush()` is not used.
Instead the fallback `self._has_uart_flush = False`  is applied.

**Successfully tested on**
* v1.22.0 (issue #13377)
* v1.22.1 (issue #13377)
* RPI_PICO-20240117-v1.23.0-preview.47.g16c6bc47c.uf2

Testsetup: rp2 and 9600 baud. Timeout measured with the scope.